### PR TITLE
Add get_loopback() function to checkout IPs from a spreadsheet 

### DIFF
--- a/lib/puppet/parser/functions/get_loopback.rb
+++ b/lib/puppet/parser/functions/get_loopback.rb
@@ -1,0 +1,38 @@
+# Lookup the loopback address from a spreadsheet, worksheet.
+# If an entry exists for this host, return it,
+# else grab the first NULL entry and assign it to us.
+
+require 'spreadsheet'
+
+
+module Puppet::Parser::Functions
+  newfunction(:get_loopback, :type => :rvalue) do |args|
+
+    file = '/home/ztpsadmin/Demo_IPAM.xls'
+    sheet = 'loopbacks'
+    key_fact = 'hostname'
+    stagefile = file + '.bak'
+
+    changed = 0
+    key = lookupvar(key_fact)
+    value = nil
+    Spreadsheet.open(file) do |book|
+      book.worksheet(sheet).each do |row|
+        if key == row[1]
+          value = row[0]
+          break
+        elsif row[0] && row[1].nil?
+          row[1] = key
+          changed = 1
+          value = row[0]
+          break
+        end
+      end
+      if changed == 1
+        book.write(stagefile)
+        File.rename(stagefile, file)
+      end
+    end
+    value
+  end
+end

--- a/spec/functions/get_loopback_spec.rb
+++ b/spec/functions/get_loopback_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'get_loopback' do
+  it { should run.with_params().and_return('1.1.1.1') }
+end

--- a/tests/get_loopback.pp
+++ b/tests/get_loopback.pp
@@ -1,0 +1,2 @@
+$loopback = get_loopback()
+notify { "The loopback address for ${::hostname} is ${loopback}": }


### PR DESCRIPTION
Uses an Excel (.xls) spreadsheet with a 'loopbacks' worksheet as an IPAM